### PR TITLE
Release v0.4.0

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -28,7 +28,7 @@ namespace Gitpod.Tool
         static void Main(string[] args)
         {
             var app     = new CommandApp();
-            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
 
             // Check for updates
             var latestVersion = GptUpdateHelper.GetLatestVersion().Result;

--- a/Program.cs
+++ b/Program.cs
@@ -57,6 +57,9 @@ namespace Gitpod.Tool
                 config.AddCommand<SelfUpdateCommand>("update")
                     .WithDescription("Update this tool to the latest version");
 
+                config.AddCommand<AskCommand>("ask")
+                    .WithDescription("Ask the gitpod ai");
+
                 config.AddBranch("config", config =>
                 {
                     config.SetDescription("Creates or verify the configuration file");

--- a/Program.cs
+++ b/Program.cs
@@ -18,6 +18,8 @@ using YamlDotNet.Serialization;
 using Gitpod.Tool.Commands.Config;
 using Gitpod.Tool.Commands.Services;
 using Gitpod.Tool.Commands.ModeJS;
+using Gitpod.Tool.Commands.Restore;
+using Gitpod.Tool.Commands.NodeJS;
 
 namespace Gitpod.Tool
 {
@@ -105,9 +107,9 @@ namespace Gitpod.Tool
                     nodejs.AddCommand<NodeJSVersionCommand>("version")
                         .WithAlias("v")
                         .WithDescription("Shows or sets the currently used NodeJS Version");
-                    nodejs.AddCommand<PhpRestoreCommand>("restore")
+                    nodejs.AddCommand<NodeJSRestoreCommand>("restore")
                         .WithAlias("r")
-                        .WithDescription("Restores a previously set NodeJS version [red]Not implemented yet[/]");
+                        .WithDescription("Restores a previously set NodeJS version");
 
                     if (addidionalCommands.ContainsKey("nodejs")) {
                         foreach (CustomCommand cmd in addidionalCommands["nodejs"].Commands) {
@@ -182,7 +184,30 @@ namespace Gitpod.Tool
                     }
                 });
 
-                var reservedBranches = new List<String>() { "default", "config", "php", "nodejs", "apache", "mysql", "services" };
+                config.AddBranch("restore", restore =>
+                {
+                    restore.SetDescription("Restore settings separate for nodejs or php, or for all at once ");
+                    
+                    restore.AddCommand<RestoreAllCommand>("all")
+                        .WithAlias("a")
+                        .WithDescription("Restore all settings");
+                    restore.AddCommand<RestorePhpCommand>("php")
+                        .WithAlias("p")
+                        .WithDescription("Restore settings for php");
+                    restore.AddCommand<RestoreNodeJsCommand>("nodejs")
+                        .WithAlias("n")
+                        .WithDescription("Restore settings for NodeJS");
+
+                    if (addidionalCommands.ContainsKey("restore")) {
+                        foreach (CustomCommand cmd in addidionalCommands["restore"].Commands) {
+                            restore.AddCommand<ShellFileCommand>(cmd.Command)
+                                .WithData(cmd)
+                                .WithDescription(cmd.Description);
+                        }
+                    }
+                });
+
+                var reservedBranches = new List<String>() { "default", "config", "php", "nodejs", "apache", "mysql", "services", "restore" };
 
                 // Add branches that haven´t been added yet via custom commands
                 foreach (KeyValuePair<string, CustomBranch> entry in addidionalCommands.Where(x => !reservedBranches.Contains(x.Key))) {

--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,7 @@ using System.IO;
 using YamlDotNet.Serialization;
 using Gitpod.Tool.Commands.Config;
 using Gitpod.Tool.Commands.Services;
+using Gitpod.Tool.Commands.ModeJS;
 
 namespace Gitpod.Tool
 {
@@ -99,11 +100,11 @@ namespace Gitpod.Tool
 
                 config.AddBranch("nodejs", nodejs =>
                 {
-                    nodejs.SetDescription("Different commands to change active nodejs version, etc. [red]Not implemented yet[/]");
+                    nodejs.SetDescription("Different commands to change active nodejs version, etc.");
                     
-                    nodejs.AddCommand<NotYetImplementedCommand>("version")
+                    nodejs.AddCommand<NodeJSVersionCommand>("version")
                         .WithAlias("v")
-                        .WithDescription("Shows or sets the currently used NodeJS Version [red]Not implemented yet[/]");
+                        .WithDescription("Shows or sets the currently used NodeJS Version");
                     nodejs.AddCommand<PhpRestoreCommand>("restore")
                         .WithAlias("r")
                         .WithDescription("Restores a previously set NodeJS version [red]Not implemented yet[/]");

--- a/Program.cs
+++ b/Program.cs
@@ -80,10 +80,10 @@ namespace Gitpod.Tool
                         .WithDescription("Shows or sets the currently used PHP Version");
                     php.AddCommand<PhpIniCommand>("ini")
                         .WithAlias("i")
-                        .WithDescription("Different functions for PHP ini files like updating or changing values");
+                        .WithDescription("Change the value of a PHP setting.");
                     php.AddCommand<PhpRestoreCommand>("restore")
                         .WithAlias("r")
-                        .WithDescription("Restores a previously set PHP version and their ini files");
+                        .WithDescription("Restores a previously set PHP version and their settings");
                     php.AddCommand<NotYetImplementedCommand>("debug")
                         .WithAlias("d")
                         .WithDescription("Enables/Disables xdebug [red]Not implemented yet[/]");

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ This CLI Tool aims to make it easier to use Gitpod for web development. It is st
 - [ ] Split php settings for cli and web
 - [ ] Select php version via dropdown, similar to services
 - [ ] Add php modules via command
+- [ ] Ability to override gpt.yml so a user can define custom services, in case he prefers service x instead of service y
+- [ ] Define env variables via config file
+- [ ] Add a general restore command which restores all settings instead of calling gpt php restore, gpt nodejs restore etc.
 
 ## Documentation
 The documentation can be found under [GPT Documentation](https://derroylo.github.io). If you want to try it, open [Shopware workspace sample](https://github.com/Derroylo/shopware-workspace-sample) in gitpod. In the terminal type `gpt -h` to get a list of the available commands.

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ This CLI Tool aims to make it easier to use Gitpod for web development. It is st
 - [x] Split php settings for cli and web
 - [x] Select php version via dropdown, similar to services
 - [x] Change the nodejs version
-- [ ] Persist updates of gpt between workspace restarts
+- [X] Persist updates of gpt between workspace restarts
+- [x] Add a general restore command which restores all settings instead of calling gpt php restore, gpt nodejs restore etc.
 - [ ] Enable/Disable xdebug on the fly
 - [ ] Import/Export the database or create/restore Snapshots
 - [ ] Add the ability to save a file and/or folder as env variable
 - [ ] Add php modules via command
 - [ ] Ability to override gpt.yml so a user can define custom services, in case he prefers service x instead of service y
 - [ ] Define env variables via config file
-- [ ] Add a general restore command which restores all settings instead of calling gpt php restore, gpt nodejs restore etc.
 - [ ] Implement a method to reuse the index for phpstorm within prebuilds (phpstorm can use a shared index)
+- [ ] Rewrite the config file handling, it needs to be more robust and not overwritting any comments or formatting
 
 ## Documentation
 The documentation can be found under [GPT Documentation](https://derroylo.github.io). If you want to try it, open [Shopware workspace sample](https://github.com/Derroylo/shopware-workspace-sample) in gitpod. In the terminal type `gpt -h` to get a list of the available commands.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ This CLI Tool aims to make it easier to use Gitpod for web development. It is st
 - [ ] Import/Export the database or create/restore Snapshots
 - [ ] Add the ability to save a file and/or folder as env variable
 - [ ] Add php modules via command
-- [ ] Ability to override gpt.yml so a user can define custom services, in case he prefers service x instead of service y
-- [ ] Define env variables via config file
-- [ ] Implement a method to reuse the index for phpstorm within prebuilds (phpstorm can use a shared index)
-- [ ] Rewrite the config file handling, it needs to be more robust and not overwritting any comments or formatting
 
 ## Documentation
 The documentation can be found under [GPT Documentation](https://derroylo.github.io). If you want to try it, open [Shopware workspace sample](https://github.com/Derroylo/shopware-workspace-sample) in gitpod. In the terminal type `gpt -h` to get a list of the available commands.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This CLI Tool aims to make it easier to use Gitpod for web development. It is st
 - [ ] Import/Export the database or create/restore Snapshots
 - [ ] Add the ability to save a file and/or folder as env variable
 - [ ] Add php modules via command
+- [ ] Implement a method to reuse the index for phpstorm within prebuilds (phpstorm can use a shared index)
 
 ## Documentation
 The documentation can be found under [GPT Documentation](https://derroylo.github.io). If you want to try it, open [Shopware workspace sample](https://github.com/Derroylo/shopware-workspace-sample) in gitpod. In the terminal type `gpt -h` to get a list of the available commands.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ This CLI Tool aims to make it easier to use Gitpod for web development. It is st
 - [x] Define additional folders that should be included for extending this tool via shell scripts
 - [x] Split php settings for cli and web
 - [x] Select php version via dropdown, similar to services
+- [x] Change the nodejs version
+- [ ] Persist updates of gpt between workspace restarts
 - [ ] Enable/Disable xdebug on the fly
-- [ ] Change the nodejs version
 - [ ] Import/Export the database or create/restore Snapshots
 - [ ] Add the ability to save a file and/or folder as env variable
 - [ ] Add php modules via command
 - [ ] Ability to override gpt.yml so a user can define custom services, in case he prefers service x instead of service y
 - [ ] Define env variables via config file
 - [ ] Add a general restore command which restores all settings instead of calling gpt php restore, gpt nodejs restore etc.
+- [ ] Implement a method to reuse the index for phpstorm within prebuilds (phpstorm can use a shared index)
 
 ## Documentation
 The documentation can be found under [GPT Documentation](https://derroylo.github.io). If you want to try it, open [Shopware workspace sample](https://github.com/Derroylo/shopware-workspace-sample) in gitpod. In the terminal type `gpt -h` to get a list of the available commands.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This CLI Tool aims to make it easier to use Gitpod for web development. It is st
 - [x] Ability to update the tool via command
 - [x] Define additional folders that should be included for extending this tool via shell scripts
 - [x] Split php settings for cli and web
+- [x] Select php version via dropdown, similar to services
 - [ ] Enable/Disable xdebug on the fly
 - [ ] Change the nodejs version
 - [ ] Import/Export the database or create/restore Snapshots
 - [ ] Add the ability to save a file and/or folder as env variable
-- [ ] Select php version via dropdown, similar to services
 - [ ] Add php modules via command
 - [ ] Ability to override gpt.yml so a user can define custom services, in case he prefers service x instead of service y
 - [ ] Define env variables via config file

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This CLI Tool aims to make it easier to use Gitpod for web development. It is st
 - [x] Make the Tool extendable via shell scripts
 - [x] Save the tool configurations in a yml file
 - [x] Ability to update the tool via command
+- [x] Define additional folders that should be included for extending this tool via shell scripts
+- [x] Split php settings for cli and web
 - [ ] Enable/Disable xdebug on the fly
 - [ ] Change the nodejs version
 - [ ] Import/Export the database or create/restore Snapshots
-- [ ] Define additional folders that should be included for extending this tool via shell scripts
 - [ ] Add the ability to save a file and/or folder as env variable
-- [ ] Split php settings for cli and web
 - [ ] Select php version via dropdown, similar to services
 - [ ] Add php modules via command
 - [ ] Ability to override gpt.yml so a user can define custom services, in case he prefers service x instead of service y

--- a/classes/configuration/ConfigConfiguration.cs
+++ b/classes/configuration/ConfigConfiguration.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Gitpod.Tool.Classes.Configuration
+{
+    class ConfigConfiguration
+    {
+        private bool allowPreReleases = false;
+
+        public bool AllowPreReleases { get { return this.allowPreReleases; } set { this.allowPreReleases = value; }}
+    }
+}

--- a/classes/configuration/Configuration.cs
+++ b/classes/configuration/Configuration.cs
@@ -5,6 +5,10 @@ namespace Gitpod.Tool.Classes.Configuration
 {
     class Configuration
     {
+        private ConfigConfiguration config = new ConfigConfiguration();
+
+        public ConfigConfiguration Config { get { return config; } set { config = value; } }
+
         private PhpConfiguration php = new PhpConfiguration();
 
         public PhpConfiguration Php { get { return php; } set { php = value; } }

--- a/classes/configuration/Configuration.cs
+++ b/classes/configuration/Configuration.cs
@@ -12,5 +12,9 @@ namespace Gitpod.Tool.Classes.Configuration
         private ServiceConfiguration services = new ServiceConfiguration();
 
         public ServiceConfiguration Services { get { return services; } set { services = value; } }
+
+        private ShellScriptsConfiguration shellScripts = new ShellScriptsConfiguration();
+
+        public ShellScriptsConfiguration ShellScripts { get { return shellScripts; } set { shellScripts = value; } }
     }
 }

--- a/classes/configuration/Configuration.cs
+++ b/classes/configuration/Configuration.cs
@@ -9,6 +9,10 @@ namespace Gitpod.Tool.Classes.Configuration
 
         public PhpConfiguration Php { get { return php; } set { php = value; } }
 
+        private NodeJsConfiguration nodejs = new NodeJsConfiguration();
+
+        public NodeJsConfiguration Nodejs { get { return nodejs; } set { nodejs = value; } }
+
         private ServiceConfiguration services = new ServiceConfiguration();
 
         public ServiceConfiguration Services { get { return services; } set { services = value; } }

--- a/classes/configuration/NodeJsConfiguration.cs
+++ b/classes/configuration/NodeJsConfiguration.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Gitpod.Tool.Classes.Configuration
+{
+    class NodeJsConfiguration
+    {
+        private string version = String.Empty;
+
+        public string Version { get { return this.version; } set { this.version = value; }}
+    }
+}

--- a/classes/configuration/PhpConfiguration.cs
+++ b/classes/configuration/PhpConfiguration.cs
@@ -9,11 +9,19 @@ namespace Gitpod.Tool.Classes.Configuration
 
         private Dictionary<string, string> config = new Dictionary<string, string>();
 
+        private Dictionary<string, string> configWeb = new Dictionary<string, string>();
+
+        private Dictionary<string, string> configCLI = new Dictionary<string, string>();
+
         private List<string> packages = new List<string>();
 
         public string Version { get { return this.version; } set { this.version = value; }}
 
         public Dictionary<string, string> Config { get { return this.config; } set { this.config = value; }}
+
+        public Dictionary<string, string> ConfigWeb { get { return this.configWeb; } set { this.configWeb = value; }}
+
+        public Dictionary<string, string> ConfigCLI { get { return this.configCLI; } set { this.configCLI = value; }}
 
         public List<string> Packages { get { return this.packages; } set { this.packages = value; }}
     }

--- a/classes/configuration/ServiceConfiguration.cs
+++ b/classes/configuration/ServiceConfiguration.cs
@@ -8,5 +8,9 @@ namespace Gitpod.Tool.Classes.Configuration
         private List<string> active = new List<string>();
 
         public List<string> Active { get { return this.active; } set { this.active = value; }}
+        
+        private String file = null;
+
+        public String File { get { return this.file; } set { this.file = value; } }
     }
 }

--- a/classes/configuration/ServiceConfiguration.cs
+++ b/classes/configuration/ServiceConfiguration.cs
@@ -9,8 +9,8 @@ namespace Gitpod.Tool.Classes.Configuration
 
         public List<string> Active { get { return this.active; } set { this.active = value; }}
         
-        private String file = null;
+        private string file = null;
 
-        public String File { get { return this.file; } set { this.file = value; } }
+        public string File { get { return this.file; } set { this.file = value; } }
     }
 }

--- a/classes/configuration/ShellScriptsConfiguration.cs
+++ b/classes/configuration/ShellScriptsConfiguration.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Gitpod.Tool.Classes.Configuration
+{
+    class ShellScriptsConfiguration
+    {
+        private List<string> additionalDirectories = new List<string>();
+
+        public List<string> AdditionalDirectories { get { return this.additionalDirectories; } set { this.additionalDirectories = value; }}
+    }
+}

--- a/commands/AskCommand.cs
+++ b/commands/AskCommand.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Gitpod.Tool.Helper;
+using Newtonsoft.Json;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Gitpod.Tool.Commands
+{   
+    class AskCommand : Command<AskCommand.Settings>
+    {
+        private static readonly HttpClient client = new HttpClient();
+
+        public class Settings : CommandSettings
+        {
+        }
+
+        public override int Execute(CommandContext context, Settings settings)
+        {
+            var question = AnsiConsole.Ask<string>("What's your question?");
+
+            Task<GitpodAIAnswer> result = Task.Run<GitpodAIAnswer>(async() => await AskGitpodAI(question));
+            
+            GitpodAIAnswer answer = result.Result;
+
+            if (answer.error != null && answer.error.Length > 0) {
+                AnsiConsole.WriteLine("The following error occured:");
+                AnsiConsole.WriteLine(answer.error);
+                AnsiConsole.WriteLine(answer.message);
+
+                return 0;
+            }
+
+            var rule = new Rule("[green]Answer[/]");
+            rule.Justification = Justify.Left;
+            AnsiConsole.Write(rule);
+
+            AnsiConsole.WriteLine(" ");
+            AnsiConsole.WriteLine(answer.answer);
+            AnsiConsole.WriteLine(" ");
+
+            if (answer.sources != null && answer.sources.Length > 0) {
+                rule = new Rule("[green]Sources[/]");
+                rule.Justification = Justify.Left;
+                AnsiConsole.Write(rule);
+
+                for (int i = 0; i < answer.sources.Length; i++) {
+                    AnsiConsole.WriteLine(answer.sources[i]);
+                }
+            }
+
+            rule = new Rule("[green]Info[/]");
+            rule.Justification = Justify.Left;
+            AnsiConsole.Write(rule);
+
+            AnsiConsole.WriteLine("You have " + answer.RateLimitRemaining + " questions remaining of " + answer.RateLimitLimit + ". The rate limit will reset every " + answer.RateLimitReset + " seconds");
+
+            return 0;
+        }
+
+        private async Task<GitpodAIAnswer> AskGitpodAI(string question)
+        {
+            var data = new StringContent(
+                JsonConvert.SerializeObject(
+                    new {
+                        question = question
+                    }
+                ),
+                Encoding.UTF8, 
+                new MediaTypeHeaderValue("application/json")
+            );
+            
+            var response = await client.PostAsync("https://docs-ai.gitpod.io/v1/ask", data);
+            var responseString = await response.Content.ReadAsStringAsync();
+
+            var responseObject = JsonConvert.DeserializeObject<GitpodAIAnswer>(responseString);
+
+            responseObject.RateLimitLimit = response.Headers.GetValues("X-Ratelimit-Limit").FirstOrDefault();
+            responseObject.RateLimitRemaining = response.Headers.GetValues("X-Ratelimit-Remaining").FirstOrDefault();
+            responseObject.RateLimitReset = response.Headers.GetValues("X-Ratelimit-Reset").FirstOrDefault();
+
+            return responseObject;
+        }
+    }
+
+    internal class GitpodAIAnswer
+    {
+        public string answer { get; set; }
+        public string[] sources { get; set; }
+        public string message { get; set; }
+        public string error { get; set; }
+        public string RateLimitLimit { get; set; }
+        public string RateLimitRemaining { get; set; }
+        public string RateLimitReset { get; set; }
+    }
+}

--- a/commands/config/VerifyConfigCommand.cs
+++ b/commands/config/VerifyConfigCommand.cs
@@ -39,6 +39,7 @@ namespace Gitpod.Tool.Commands.Config
 
             this.OutputPhpSettings();
             this.OutputServiceSettings();
+            this.OutputShellScriptSettings();
 
             return 0;
         }
@@ -111,6 +112,41 @@ namespace Gitpod.Tool.Commands.Config
                 
                 // Render the table to the console
                 AnsiConsole.Write(settingsTable);
+            }
+        }
+
+        private void OutputShellScriptSettings()
+        {
+            var rule = new Rule("[red]Shell scripts[/]");
+            rule.Justification = Justify.Left;
+            AnsiConsole.Write(rule);
+
+            if (GptConfigHelper.Config.ShellScripts.AdditionalDirectories.Count > 0) {
+                AnsiConsole.WriteLine("Additional directories:");
+
+                // Create a table
+                var directoriesTable = new Table();
+
+                // Add columns
+                directoriesTable.AddColumn("Directory");
+                directoriesTable.AddColumn("Exists");
+                directoriesTable.AddColumn("Scripts found");
+
+                var currentDir = Directory.GetCurrentDirectory() + "/";
+
+                foreach(string item in GptConfigHelper.Config.ShellScripts.AdditionalDirectories) {
+                    bool dirExists = Directory.Exists(currentDir + item);
+                    int scriptsFound = 0;
+
+                    if (dirExists) {
+                        scriptsFound = Directory.GetFiles(currentDir + item, "*.sh", SearchOption.AllDirectories).Count();
+                    }
+
+                    directoriesTable.AddRow(item, dirExists ? "[green1]Yes[/]" : "[red]No[/]", scriptsFound.ToString());
+                }
+                
+                // Render the table to the console
+                AnsiConsole.Write(directoriesTable);
             }
         }
     }   

--- a/commands/config/VerifyConfigCommand.cs
+++ b/commands/config/VerifyConfigCommand.cs
@@ -13,7 +13,20 @@ namespace Gitpod.Tool.Commands.Config
     {
         public class Settings : CommandSettings
         {
-            
+            [CommandOption("-p|--php")]
+            [Description("Verify php settings")]
+            [DefaultValue(false)]
+            public bool VerifyPhp { get; set; }
+
+            [CommandOption("-s|--services")]
+            [Description("Verify services settings")]
+            [DefaultValue(false)]
+            public bool VerifyServices { get; set; }
+
+            [CommandOption("-S|--shell")]
+            [Description("Verify shell script settings")]
+            [DefaultValue(false)]
+            public bool VerifyShellScripts { get; set; }
         }
 
         public override int Execute(CommandContext context, Settings settings)
@@ -30,16 +43,29 @@ namespace Gitpod.Tool.Commands.Config
 
             GptConfigHelper.ReadConfigFile(true, true);
 
-
             if (GptConfigHelper.Config == null) {
                 AnsiConsole.MarkupLine("[red]The config object is empty, either the config file has no content or an error appeared during parsing of its content.[/]");
 
                 return 0;
             }
 
-            this.OutputPhpSettings();
-            this.OutputServiceSettings();
-            this.OutputShellScriptSettings();
+            bool showSingleOutput = false;
+
+            if (settings.VerifyPhp || settings.VerifyServices || settings.VerifyShellScripts) {
+                showSingleOutput = true;
+            }
+
+            if (!showSingleOutput || settings.VerifyPhp) {
+                this.OutputPhpSettings();
+            }
+            
+            if (!showSingleOutput || settings.VerifyServices) {
+                this.OutputServiceSettings();
+            }
+
+            if (!showSingleOutput || settings.VerifyShellScripts) {
+                this.OutputShellScriptSettings();
+            }
 
             return 0;
         }

--- a/commands/config/VerifyConfigCommand.cs
+++ b/commands/config/VerifyConfigCommand.cs
@@ -18,6 +18,11 @@ namespace Gitpod.Tool.Commands.Config
             [DefaultValue(false)]
             public bool VerifyPhp { get; set; }
 
+            [CommandOption("-n|--nodejs")]
+            [Description("Verify NodeJS settings")]
+            [DefaultValue(false)]
+            public bool VerifyNodeJs { get; set; }
+
             [CommandOption("-s|--services")]
             [Description("Verify services settings")]
             [DefaultValue(false)]
@@ -51,7 +56,7 @@ namespace Gitpod.Tool.Commands.Config
 
             bool showSingleOutput = false;
 
-            if (settings.VerifyPhp || settings.VerifyServices || settings.VerifyShellScripts) {
+            if (settings.VerifyPhp || settings.VerifyServices || settings.VerifyShellScripts || settings.VerifyNodeJs) {
                 showSingleOutput = true;
             }
 
@@ -65,6 +70,10 @@ namespace Gitpod.Tool.Commands.Config
 
             if (!showSingleOutput || settings.VerifyShellScripts) {
                 this.OutputShellScriptSettings();
+            }
+
+            if (!showSingleOutput || settings.VerifyNodeJs) {
+                this.OutputNodeJsSettings();
             }
 
             return 0;
@@ -150,6 +159,18 @@ namespace Gitpod.Tool.Commands.Config
                 
                 // Render the table to the console
                 AnsiConsole.Write(settingsTable);
+            }
+        }
+
+        private void OutputNodeJsSettings()
+        {
+            var rule = new Rule("[red]NodeJS[/]");
+            rule.Justification = Justify.Left;
+            AnsiConsole.Write(rule);
+
+            if (GptConfigHelper.Config.Nodejs.Version != String.Empty) {
+                // Show NodeJS configuration
+                AnsiConsole.WriteLine("Version: " + GptConfigHelper.Config.Nodejs.Version);
             }
         }
 

--- a/commands/config/VerifyConfigCommand.cs
+++ b/commands/config/VerifyConfigCommand.cs
@@ -56,7 +56,7 @@ namespace Gitpod.Tool.Commands.Config
             }
             
             if (GptConfigHelper.Config.Php.Config.Count > 0) {
-                AnsiConsole.WriteLine("Settings:");
+                AnsiConsole.WriteLine("Overrides (CLI and Web):");
 
                 // Create a table
                 var settingsTable = new Table();
@@ -66,6 +66,42 @@ namespace Gitpod.Tool.Commands.Config
                 settingsTable.AddColumn("Value");
 
                 foreach(KeyValuePair<string, string> item in GptConfigHelper.Config.Php.Config) {
+                    settingsTable.AddRow(item.Key, item.Value);
+                }
+                
+                // Render the table to the console
+                AnsiConsole.Write(settingsTable);
+            }
+
+            if (GptConfigHelper.Config.Php.ConfigCLI.Count > 0) {
+                AnsiConsole.WriteLine("Overrides CLI:");
+
+                // Create a table
+                var settingsTable = new Table();
+
+                // Add columns
+                settingsTable.AddColumn("Name");
+                settingsTable.AddColumn("Value");
+
+                foreach(KeyValuePair<string, string> item in GptConfigHelper.Config.Php.ConfigCLI) {
+                    settingsTable.AddRow(item.Key, item.Value);
+                }
+                
+                // Render the table to the console
+                AnsiConsole.Write(settingsTable);
+            }
+
+            if (GptConfigHelper.Config.Php.ConfigWeb.Count > 0) {
+                AnsiConsole.WriteLine("Overrides Web:");
+
+                // Create a table
+                var settingsTable = new Table();
+
+                // Add columns
+                settingsTable.AddColumn("Name");
+                settingsTable.AddColumn("Value");
+
+                foreach(KeyValuePair<string, string> item in GptConfigHelper.Config.Php.ConfigWeb) {
                     settingsTable.AddRow(item.Key, item.Value);
                 }
                 

--- a/commands/nodejs/NodeJSVersionCommand.cs
+++ b/commands/nodejs/NodeJSVersionCommand.cs
@@ -1,0 +1,58 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System.Linq;
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+using Gitpod.Tool.Helper;
+using System.IO;
+
+namespace Gitpod.Tool.Commands.ModeJS
+{
+    class NodeJSVersionCommand : Command<NodeJSVersionCommand.Settings>
+    {
+        private Settings settings;
+
+        public class Settings : CommandSettings
+        {
+            [CommandArgument(0, "[Version]")]
+            [Description("Set this parameter to change the active nodejs version. Leave this parameter empty to show the current version.")]
+            public string Version { get; set; }
+
+            [CommandOption("-d|--debug")]
+            [Description("Outputs debug information")]
+            [DefaultValue(false)]
+            public bool Debug { get; set; }
+        }
+
+        public override int Execute(CommandContext context, Settings settings)
+        {
+            this.settings = settings;
+
+            if (this.settings.Version != null) {
+                NodeJSHelper.SetNewNodeJSVersion(this.settings.Version, this.settings.Debug);
+
+                return 0;
+            }
+
+            string result = NodeJSHelper.GetCurrentNodeJSVersion();
+            AnsiConsole.WriteLine(result);
+
+            if (!AnsiConsole.Confirm("Do you want to change the active nodejs version?", false)) {
+                return 0;
+            }
+
+            var availableNodeJSVersions = NodeJSHelper.GetAvailableNodeJSVersions();
+
+            var newVersion = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select the new active NodeJS version")
+                        .PageSize(10)
+                        .AddChoices(availableNodeJSVersions.ToArray<string>())
+                );
+
+            NodeJSHelper.SetNewNodeJSVersion(newVersion, this.settings.Debug);
+
+            return 0;
+        }        
+    }
+}

--- a/commands/nodejs/NodeJsRestoreCommand.cs
+++ b/commands/nodejs/NodeJsRestoreCommand.cs
@@ -5,9 +5,9 @@ using Gitpod.Tool.Helper;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
-namespace Gitpod.Tool.Commands.Php
+namespace Gitpod.Tool.Commands.NodeJS
 {
-    class PhpRestoreCommand : Command<PhpRestoreCommand.Settings>
+    class NodeJSRestoreCommand : Command<NodeJSRestoreCommand.Settings>
     {
         private Settings settings;
 
@@ -23,9 +23,8 @@ namespace Gitpod.Tool.Commands.Php
         {
             this.settings = settings;
 
-            RestoreHelper.RestorePhpVersion(settings.Debug);
-            RestoreHelper.RestorePhpIni(settings.Debug);
-
+            RestoreHelper.RestoreNodeJsVersion(settings.Debug);
+            
             return 0;
         }
     }

--- a/commands/php/PhpRestoreCommand.cs
+++ b/commands/php/PhpRestoreCommand.cs
@@ -33,7 +33,7 @@ namespace Gitpod.Tool.Commands.Php
         {
             AnsiConsole.Write("Checking if php version has been set via config....");
 
-            if (GptConfigHelper.Config == null || GptConfigHelper.Config.Php == null || GptConfigHelper.Config.Php.Version == String.Empty) {
+            if (GptConfigHelper.Config.Php.Version == String.Empty) {
                 AnsiConsole.MarkupLine("[cyan3]Not found[/]");
 
                 return;
@@ -46,6 +46,16 @@ namespace Gitpod.Tool.Commands.Php
 
         private void RestorePhpIni()
         {
+            AnsiConsole.Write("Checking if php settings has been set via config....");
+
+            if (GptConfigHelper.Config.Php.Config.Count == 0 && GptConfigHelper.Config.Php.ConfigCLI.Count == 0 && GptConfigHelper.Config.Php.ConfigWeb.Count == 0) {
+                AnsiConsole.MarkupLine("[cyan3]Not found[/]");
+
+                return;
+            }
+
+            AnsiConsole.MarkupLine("[green1]Found[/]");
+
             PhpHelper.UpdatePhpIniFiles(this.settings.Debug);
         }
     }

--- a/commands/php/PhpVersionCommand.cs
+++ b/commands/php/PhpVersionCommand.cs
@@ -28,14 +28,29 @@ namespace Gitpod.Tool.Commands.Php
         {
             this.settings = settings;
 
-            if (this.settings.Version == null) {
-                string result = PhpHelper.GetCurrentPhpVersionOutput();
-                AnsiConsole.WriteLine(result);
+            if (this.settings.Version != null) {
+                PhpHelper.SetNewPhpVersion(this.settings.Version, this.settings.Debug);
 
                 return 0;
             }
 
-            PhpHelper.SetNewPhpVersion(this.settings.Version, this.settings.Debug);
+            string result = PhpHelper.GetCurrentPhpVersionOutput();
+            AnsiConsole.WriteLine(result);
+
+            if (!AnsiConsole.Confirm("Do you want to change the active php version?", false)) {
+                return 0;
+            }
+
+            var availablePhpVersions = PhpHelper.GetAvailablePhpVersions();
+
+            var newVersion = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select the new active php version")
+                        .PageSize(5)
+                        .AddChoices(availablePhpVersions.ToArray<string>())
+                );
+
+            PhpHelper.SetNewPhpVersion(newVersion, this.settings.Debug);
 
             return 0;
         }        

--- a/commands/restore/RestoreAllCommand.cs
+++ b/commands/restore/RestoreAllCommand.cs
@@ -5,9 +5,9 @@ using Gitpod.Tool.Helper;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
-namespace Gitpod.Tool.Commands.Php
+namespace Gitpod.Tool.Commands.Restore
 {
-    class PhpRestoreCommand : Command<PhpRestoreCommand.Settings>
+    class RestoreAllCommand : Command<RestoreAllCommand.Settings>
     {
         private Settings settings;
 
@@ -25,6 +25,8 @@ namespace Gitpod.Tool.Commands.Php
 
             RestoreHelper.RestorePhpVersion(settings.Debug);
             RestoreHelper.RestorePhpIni(settings.Debug);
+            
+            RestoreHelper.RestoreNodeJsVersion(settings.Debug);
 
             return 0;
         }

--- a/commands/restore/RestoreNodeJsCommand.cs
+++ b/commands/restore/RestoreNodeJsCommand.cs
@@ -5,9 +5,9 @@ using Gitpod.Tool.Helper;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
-namespace Gitpod.Tool.Commands.Php
+namespace Gitpod.Tool.Commands.Restore
 {
-    class PhpRestoreCommand : Command<PhpRestoreCommand.Settings>
+    class RestoreNodeJsCommand : Command<RestoreNodeJsCommand.Settings>
     {
         private Settings settings;
 
@@ -23,9 +23,8 @@ namespace Gitpod.Tool.Commands.Php
         {
             this.settings = settings;
 
-            RestoreHelper.RestorePhpVersion(settings.Debug);
-            RestoreHelper.RestorePhpIni(settings.Debug);
-
+            RestoreHelper.RestoreNodeJsVersion(settings.Debug);
+            
             return 0;
         }
     }

--- a/commands/restore/RestorePhpCommand.cs
+++ b/commands/restore/RestorePhpCommand.cs
@@ -5,9 +5,9 @@ using Gitpod.Tool.Helper;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
-namespace Gitpod.Tool.Commands.Php
+namespace Gitpod.Tool.Commands.Restore
 {
-    class PhpRestoreCommand : Command<PhpRestoreCommand.Settings>
+    class RestorePhpCommand : Command<RestorePhpCommand.Settings>
     {
         private Settings settings;
 
@@ -25,7 +25,7 @@ namespace Gitpod.Tool.Commands.Php
 
             RestoreHelper.RestorePhpVersion(settings.Debug);
             RestoreHelper.RestorePhpIni(settings.Debug);
-
+            
             return 0;
         }
     }

--- a/commands/services/ListServicesCommand.cs
+++ b/commands/services/ListServicesCommand.cs
@@ -7,6 +7,7 @@ using Gitpod.Tool.Helper;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using YamlDotNet.Serialization.NamingConventions;
+using System;
 
 namespace Gitpod.Tool.Commands.Services
 {
@@ -19,13 +20,13 @@ namespace Gitpod.Tool.Commands.Services
 
         public override int Execute(CommandContext context, Settings settings)
         {
-            if (!File.Exists("docker-compose.yml")) {
-                AnsiConsole.MarkupLine("[red]docker-compose.yml not found[/]");
+            if (!File.Exists(DockerComposeHelper.GetFile())) {
+                AnsiConsole.MarkupLine(String.Format("[red]{0} not found[/]", DockerComposeHelper.GetFile()));
 
                 return 0;
             }
 
-            var services = DockerComposeHelper.GetServices("docker-compose.yml");
+            var services = DockerComposeHelper.GetServices(DockerComposeHelper.GetFile());
 
             var servicesTable = new Table();
 

--- a/commands/services/SelectServicesCommand.cs
+++ b/commands/services/SelectServicesCommand.cs
@@ -21,13 +21,13 @@ namespace Gitpod.Tool.Commands.Services
 
         public override int Execute(CommandContext context, Settings settings)
         {
-            if (!File.Exists("docker-compose.yml")) {
-                AnsiConsole.MarkupLine("[red]docker-compose.yml not found[/]");
+            if (!File.Exists(DockerComposeHelper.GetFile())) {
+                AnsiConsole.MarkupLine(String.Format("[red]{0} not found[/]", DockerComposeHelper.GetFile()));
 
                 return 0;
             }
 
-            var services = DockerComposeHelper.GetServices("docker-compose.yml");
+            var services = DockerComposeHelper.GetServices(DockerComposeHelper.GetFile());
             var serviceCategories = new Dictionary<string, List<string>>();
 
             serviceCategories.Add("unknown", new List<string>());

--- a/commands/services/StartServicesCommand.cs
+++ b/commands/services/StartServicesCommand.cs
@@ -23,13 +23,13 @@ namespace Gitpod.Tool.Commands.Services
 
         public override int Execute(CommandContext context, Settings settings)
         {
-            if (!File.Exists("docker-compose.yml")) {
-                AnsiConsole.MarkupLine("[red]docker-compose.yml not found[/]");
+            if (!File.Exists(DockerComposeHelper.GetFile())) {
+                AnsiConsole.MarkupLine(String.Format("[red]{0} not found[/]", DockerComposeHelper.GetFile()));
 
                 return 0;
             }
 
-            var services = DockerComposeHelper.GetServices("docker-compose.yml");
+            var services = DockerComposeHelper.GetServices(DockerComposeHelper.GetFile());
 
             if (GptConfigHelper.Config.Services == null || GptConfigHelper.Config.Services.Active.Count == 0) {
                 AnsiConsole.WriteLine("[red]No active services selected[/]");

--- a/commands/services/StartServicesCommand.cs
+++ b/commands/services/StartServicesCommand.cs
@@ -15,7 +15,7 @@ namespace Gitpod.Tool.Commands.Services
     {
         public class Settings : CommandSettings
         {
-            [CommandOption("--detached")]
+            [CommandOption("-d|--detached")]
             [Description("Outputs debug information")]
             [DefaultValue(false)]
             public bool Detached { get; set; }

--- a/commands/services/StopServicesCommand.cs
+++ b/commands/services/StopServicesCommand.cs
@@ -20,8 +20,8 @@ namespace Gitpod.Tool.Commands.Services
 
         public override int Execute(CommandContext context, Settings settings)
         {
-            if (!File.Exists("docker-compose.yml")) {
-                AnsiConsole.MarkupLine("[red]docker-compose.yml not found[/]");
+            if (!File.Exists(DockerComposeHelper.GetFile())) {
+                AnsiConsole.MarkupLine(String.Format("[red]{0} not found[/]", DockerComposeHelper.GetFile()));
 
                 return 0;
             }

--- a/gitpod-tool.csproj
+++ b/gitpod-tool.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="newtonsoft.json" Version="13.0.3" />
     <PackageReference Include="octokit" Version="5.1.0" />
+    <PackageReference Include="Semver" Version="2.3.0" />
     <PackageReference Include="Spectre.Console" Version="0.46.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
     <PackageReference Include="yamldotnet" Version="13.1.0" />

--- a/gitpod-tool.csproj
+++ b/gitpod-tool.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>Carsten Lohmann</Authors>
     <Product>Gitpod Tool or short gpt</Product>
     <Description>A little tool to make life easier with gitpod and web development</Description>

--- a/gpt.sh
+++ b/gpt.sh
@@ -6,12 +6,20 @@
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
+# Directory where gpt is located
+GPTDIR=$SCRIPTPATH
+
+# After an update, gpt will be installed in /workspace/.gpt so the update will not be lost after a restart
+if [[ $SCRIPTPATH == "/home/gitpod/.gpt" ]]  && [ -d "/workspace/.gpt" ] && [ -f "/workspace/.gpt/gitpod-tool.dll" ]; then
+	GPTDIR="/workspace/.gpt"
+fi
+
 # run the application and pass all arguments to it
-dotnet "$SCRIPTPATH/gitpod-tool.dll" "$@"
+dotnet "$GPTDIR/gitpod-tool.dll" "$@"
 
 # Check if the update folder exists
 if [ -d "update" ]; then
-    cd $SCRIPTPATH
+    cd $GPTDIR
 
     # Move all files from the update folder to the current one and remove it afterwards
     mv update/* .
@@ -24,26 +32,26 @@ if [ -d "update" ]; then
 fi
 
 # Check if we want to start services
-if [ -f "$SCRIPTPATH/.services_start" ]; then
-    activeServices=$(<"$SCRIPTPATH/.services_start")
+if [ -f "$GPTDIR/.services_start" ]; then
+    activeServices=$(<"$GPTDIR/.services_start")
 
-    rm "$SCRIPTPATH/.services_start"
+    rm "$GPTDIR/.services_start"
 
     docker-compose up $activeServices
 fi
 
 # Check if we want to stop services
-if [ -f "$SCRIPTPATH/.services_stop" ]; then
-    rm "$SCRIPTPATH/.services_stop"
+if [ -f "$GPTDIR/.services_stop" ]; then
+    rm "$GPTDIR/.services_stop"
 
     docker-compose stop
 fi
 
 # Check if we want to change the nodejs version
-if [ -f "$SCRIPTPATH/.nodejs" ]; then
-    version=$(<"$SCRIPTPATH/.nodejs")
+if [ -f "$GPTDIR/.nodejs" ]; then
+    version=$(<"$GPTDIR/.nodejs")
 
-    rm "$SCRIPTPATH/.nodejs"
+    rm "$GPTDIR/.nodejs"
 
     . ~/.nvm/nvm.sh
 

--- a/gpt.sh
+++ b/gpt.sh
@@ -38,3 +38,16 @@ if [ -f "$SCRIPTPATH/.services_stop" ]; then
 
     docker-compose stop
 fi
+
+# Check if we want to change the nodejs version
+if [ -f "$SCRIPTPATH/.nodejs" ]; then
+    version=$(<"$SCRIPTPATH/.nodejs")
+
+    rm "$SCRIPTPATH/.nodejs"
+
+    . ~/.nvm/nvm.sh
+
+    nvm use $version
+    
+    nvm alias default $version
+fi

--- a/helper/CustomCommandsLoader.cs
+++ b/helper/CustomCommandsLoader.cs
@@ -13,7 +13,15 @@ namespace Gitpod.Tool.Helper
         public static Dictionary<string, CustomBranch> Load()
         {           
             try {
-                return CustomCommandsLoader.SearchForShellScripts(".devEnv/gitpod/scripts");
+                var scripts = CustomCommandsLoader.SearchForShellScripts(".devEnv/gitpod/scripts");
+
+                if (GptConfigHelper.Config.ShellScripts.AdditionalDirectories.Count > 0) {
+                    foreach (string folder in GptConfigHelper.Config.ShellScripts.AdditionalDirectories) {
+                        scripts = CustomCommandsLoader.SearchForShellScripts(folder, scripts);
+                    }
+                }
+
+                return scripts;
             } catch(Exception ex) {
                 AnsiConsole.MarkupLine("[red]An exception occured during loading of custom commands[/]");
                 AnsiConsole.WriteException(ex);
@@ -36,12 +44,8 @@ namespace Gitpod.Tool.Helper
                 return commands;
             }
 
-            string[] files = Directory.GetFiles(folder);
+            string[] files = Directory.GetFiles(folder, "*.sh");
             foreach (string file in files) {
-                if (file.ToLower().Substring(file.Length - 3) != ".sh") {
-                    continue;
-                }
-
                 var shellScriptSettings = CustomCommandsLoader.ProcessShellScript(file);
                 
                 if (shellScriptSettings == null) {

--- a/helper/DockerComposeHelper.cs
+++ b/helper/DockerComposeHelper.cs
@@ -9,6 +9,11 @@ namespace Gitpod.Tool.Helper
 {
     class DockerComposeHelper
     {
+        public static string GetFile()
+        {
+            return GptConfigHelper.Config.Services.File ?? "docker-compose.yml";
+        }
+
         public static Dictionary<string, Dictionary<string, string>> GetServices(string filename)
         {
             var services = new Dictionary<string, Dictionary<string, string>>();
@@ -16,7 +21,7 @@ namespace Gitpod.Tool.Helper
             var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
                                     .WithNamingConvention(CamelCaseNamingConvention.Instance)
                                     .Build();
-            dynamic dockerCompose = deserializer.Deserialize<dynamic>(File.ReadAllText("docker-compose.yml"));
+            dynamic dockerCompose = deserializer.Deserialize<dynamic>(File.ReadAllText(filename));
 
             foreach (KeyValuePair<object, object> item in dockerCompose["services"]) {
                 var serviceInfos = new Dictionary<string, string>();

--- a/helper/GptUpdateHelper.cs
+++ b/helper/GptUpdateHelper.cs
@@ -79,7 +79,7 @@ namespace Gitpod.Tool.Helper
 
         public static bool IsUpdateAvailable()
         {
-            var currentVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            var currentVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
             var latestVersion  = (GptUpdateHelper.GetLatestVersion()).Result;
 
             SemVersion localVersion = SemVersion.Parse(currentVersion, SemVersionStyles.Strict);

--- a/helper/GptUpdateHelper.cs
+++ b/helper/GptUpdateHelper.cs
@@ -78,13 +78,25 @@ namespace Gitpod.Tool.Helper
         public static async Task<bool> UpdateToLatestRelease()
         {
             var applicationDir = AppDomain.CurrentDomain.BaseDirectory;
+            var newGptDir = "/workspace/.gpt";
+
             JObject cacheFile = JObject.Parse(File.ReadAllText(applicationDir + "releases.json"));
+
+            try {
+                if (!Directory.Exists(newGptDir)) {
+                    Directory.CreateDirectory(newGptDir);
+                }
+            } catch (Exception e) {
+                AnsiConsole.WriteException(e);
+
+                return false;
+            }
 
             try {
                 var httpClient = new HttpClient();
                 var httpResult = await httpClient.GetAsync((string) cacheFile["download_url"]);
                 using var resultStream = await httpResult.Content.ReadAsStreamAsync();
-                using var fileStream = File.Create(applicationDir + "gitpod-tool.zip");
+                using var fileStream = File.Create(newGptDir + "gitpod-tool.zip");
 
                 resultStream.CopyTo(fileStream);
             } catch (Exception e) {
@@ -93,14 +105,14 @@ namespace Gitpod.Tool.Helper
                 return false;
             }
             
-            if (!File.Exists(applicationDir + "gitpod-tool.zip")) {
+            if (!File.Exists(newGptDir + "gitpod-tool.zip")) {
                 AnsiConsole.WriteLine("Downloading the latest release failed");
 
                 return false;
             }
 
             try {
-                ZipFile.ExtractToDirectory(applicationDir + "gitpod-tool.zip", applicationDir + "update", true);
+                ZipFile.ExtractToDirectory(newGptDir + "gitpod-tool.zip", newGptDir + "update", true);
             } catch (Exception e) {
                 AnsiConsole.WriteException(e);
 

--- a/helper/GptUpdateHelper.cs
+++ b/helper/GptUpdateHelper.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using System.Reflection;
 using System.IO.Compression;
+using Semver;
 
 namespace Gitpod.Tool.Helper
 {
@@ -28,6 +29,10 @@ namespace Gitpod.Tool.Helper
             Release lastRelease = null;
 
             foreach (Release release in releases) {
+                if (release.Draft) {
+                    continue;
+                }
+
                 if (!allowPreReleases && release.Prerelease) {
                     continue;
                 }
@@ -50,7 +55,6 @@ namespace Gitpod.Tool.Helper
 
         public static async Task<string> GetLatestVersion(bool forceUpdate = false)
         {
-            forceUpdate = true;
             var applicationDir = AppDomain.CurrentDomain.BaseDirectory;
 
             if (!File.Exists(applicationDir + "releases.json") || forceUpdate) {
@@ -78,10 +82,10 @@ namespace Gitpod.Tool.Helper
             var currentVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             var latestVersion  = (GptUpdateHelper.GetLatestVersion()).Result;
 
-            Version localVersion = new Version(currentVersion);
-            Version latestRelease = new Version(latestVersion);
+            SemVersion localVersion = SemVersion.Parse(currentVersion, SemVersionStyles.Strict);
+            SemVersion latestRelease = SemVersion.Parse(latestVersion, SemVersionStyles.Strict);
 
-            int versionComparison = localVersion.CompareTo(latestRelease);
+            int versionComparison = localVersion.CompareSortOrderTo(latestRelease);
 
             if (versionComparison < 0) {
                 return true;

--- a/helper/NodeJSHelper.cs
+++ b/helper/NodeJSHelper.cs
@@ -62,6 +62,23 @@ namespace Gitpod.Tool.Helper
                     var applicationDir = AppDomain.CurrentDomain.BaseDirectory;
                     File.WriteAllText(applicationDir + ".nodejs", newVersion);
 
+                    try {
+                        if (GptConfigHelper.Config == null) {
+                            GptConfigHelper.Config = new Classes.Configuration.Configuration();
+                        }
+
+                        if (GptConfigHelper.Config.Nodejs == null) {
+                            GptConfigHelper.Config.Nodejs = new Classes.Configuration.NodeJsConfiguration();
+                        }
+
+                        GptConfigHelper.Config.Nodejs.Version = newVersion;
+                        GptConfigHelper.WriteConfigFile();
+
+                        AnsiConsole.MarkupLine("Saving the new active version so it can be restored...[green1]Done[/]");
+                    } catch {
+                        AnsiConsole.MarkupLine("Saving the new active version so it can be restored...[red]Failed[/]");
+                    }
+
                     AnsiConsole.WriteLine("NodeJS has been set to " + newVersion);
                     AnsiConsole.WriteLine("You may need to reload the terminal or open a new one to change to the new active version!");
                 });

--- a/helper/NodeJSHelper.cs
+++ b/helper/NodeJSHelper.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Newtonsoft.Json.Converters;
+using Spectre.Console;
+
+namespace Gitpod.Tool.Helper
+{
+    class NodeJSHelper
+    {  
+        public static string GetCurrentNodeJSVersionOutput()
+        {
+            return ExecCommand.Exec("node -v");
+        }
+
+        public static string GetCurrentNodeJSVersion()
+        {
+            string output = NodeJSHelper.GetCurrentNodeJSVersionOutput();
+
+            Regex regex = new Regex(@"v([0-9]+).([0-9]+).([0-9]+)");
+            Match match = regex.Match(output);
+
+            if (!match.Success) {
+                throw new Exception("Failed to parse the node version command output to find the active version.");
+            }
+
+            return output;
+        }
+
+        public static List<string> GetAvailableNodeJSVersions()
+        {
+            var availableNodeJSVersions = new List<string>();
+
+            string pattern = @"v(([0-9]+).([0-9]+).([0-9]+))";
+            string input = ExecCommand.Exec("source \"$NVM_DIR\"/nvm-lazy.sh && nvm ls-remote");
+
+            RegexOptions options = RegexOptions.Multiline;
+        
+            foreach (Match m in Regex.Matches(input, pattern, options))
+            {
+                if (!m.Groups.ContainsKey("1") || m.Groups[1].ToString().Length < 3) {
+                    continue;
+                }
+
+                availableNodeJSVersions.Insert(0, m.Groups[1].ToString());
+            }
+
+            return availableNodeJSVersions;
+        }
+
+        public static void SetNewNodeJSVersion(string newVersion, bool isDebug)
+        {
+            AnsiConsole.Status()
+                .Start("Changing to NodeJS " + newVersion + ", this can take a few mins.", ctx => 
+                {
+                    ExecCommand.Exec("source \"$NVM_DIR\"/nvm-lazy.sh && nvm install " + newVersion);
+
+                    // Write the selected version to a file, so we can change the active nodejs version via the gpt.sh script
+                    var applicationDir = AppDomain.CurrentDomain.BaseDirectory;
+                    File.WriteAllText(applicationDir + ".nodejs", newVersion);
+
+                    AnsiConsole.WriteLine("NodeJS has been set to " + newVersion);
+                    AnsiConsole.WriteLine("You may need to reload the terminal or open a new one to change to the new active version!");
+                });
+        }
+    }
+}

--- a/helper/PhpHelper.cs
+++ b/helper/PhpHelper.cs
@@ -162,9 +162,9 @@ namespace Gitpod.Tool.Helper
 
             AnsiConsole.Write("Generating custom.ini....");
 
-            var customIniPath = PhpHelper.GenerateCustomIniFilesFromConfig();
+            var customIniFiles = PhpHelper.GenerateCustomIniFilesFromConfig();
 
-            if (customIniPath == String.Empty) {
+            if (customIniFiles.Count == 0) {
                 AnsiConsole.MarkupLine("[cyan3]No custom settings found[/]");
 
                 return;
@@ -172,31 +172,35 @@ namespace Gitpod.Tool.Helper
 
             AnsiConsole.MarkupLine("[green1]Done[/]");
            
-            AnsiConsole.Write("Copy the custom.ini to the target directory....");
+            if (customIniFiles.ContainsKey("cli")) {
+                AnsiConsole.Write("Copy the custom_cli.ini to the target directory....");
 
-            string targetFile = "/etc/php/" + currentPhpVersion + "/cli/conf.d/custom.ini";
-            
-            if (isDebug) {
-                AnsiConsole.WriteLine("Copying from \"" + customIniPath + "\" to \"" + targetFile + "\"");
+                string targetFile = "/etc/php/" + currentPhpVersion + "/cli/conf.d/custom.ini";
+                
+                if (isDebug) {
+                    AnsiConsole.WriteLine("Copying from \"" + customIniFiles["cli"] + "\" to \"" + targetFile + "\"");
+                }
+                
+                ExecCommand.Exec("sudo cp " + customIniFiles["cli"] + " " + targetFile);
             }
-            
-            ExecCommand.Exec("sudo cp " + customIniPath + " " + targetFile);
 
-            targetFile = "/etc/php/" + currentPhpVersion + "/apache2/conf.d/custom.ini";
-            
-            if (isDebug) {
-                AnsiConsole.WriteLine("Copying from \"" + customIniPath + "\" to \"" + targetFile + "\"");
-            }
-            
-            ExecCommand.Exec("sudo cp " + customIniPath + " " + targetFile);
+            if (customIniFiles.ContainsKey("web")) {
+                string targetFile = "/etc/php/" + currentPhpVersion + "/apache2/conf.d/custom.ini";
+                
+                if (isDebug) {
+                    AnsiConsole.WriteLine("Copying from \"" + customIniFiles["web"] + "\" to \"" + targetFile + "\"");
+                }
+                
+                ExecCommand.Exec("sudo cp " + customIniFiles["web"] + " " + targetFile);
 
-            targetFile = "/etc/php/" + currentPhpVersion + "/apache2/conf.d/custom.ini";
-            
-            if (isDebug) {
-                AnsiConsole.WriteLine("Copying from \"" + customIniPath + "\" to \"" + targetFile + "\"");
+                targetFile = "/etc/php/" + currentPhpVersion + "/apache2/conf.d/custom.ini";
+                
+                if (isDebug) {
+                    AnsiConsole.WriteLine("Copying from \"" + customIniFiles["web"] + "\" to \"" + targetFile + "\"");
+                }
+                
+                ExecCommand.Exec("sudo cp " + customIniFiles["web"] + " " + targetFile);
             }
-            
-            ExecCommand.Exec("sudo cp " + customIniPath + " " + targetFile);
 
             AnsiConsole.MarkupLine("[green1]Done[/]");
         }
@@ -233,32 +237,73 @@ namespace Gitpod.Tool.Helper
             ExecCommand.Exec("apachectl restart");
         }
 
-        private static string GenerateCustomIniFilesFromConfig()
+        private static Dictionary<string, string> GenerateCustomIniFilesFromConfig()
         {
             var applicationDir = AppDomain.CurrentDomain.BaseDirectory;
             var iniSettingsFolder = applicationDir + "/php";
+            var customFilesWithPath = new Dictionary<string, string>();
 
             if (!Directory.Exists(iniSettingsFolder)) {
                 Directory.CreateDirectory(iniSettingsFolder);
             }
 
-            if (GptConfigHelper.Config == null) {
-                GptConfigHelper.Config = new Classes.Configuration.Configuration();
+            if (GptConfigHelper.Config.Php.Config.Count == 0 && GptConfigHelper.Config.Php.ConfigCLI.Count == 0 && GptConfigHelper.Config.Php.ConfigWeb.Count == 0) {
+                return customFilesWithPath;
             }
 
-            if (GptConfigHelper.Config.Php.Config.Count == 0) {
-                return String.Empty;
+            // Combine config and configWeb to a custom.ini for web
+            var configWeb = new Dictionary<string, string>(GptConfigHelper.Config.Php.ConfigWeb);
+            var customWeb = new Dictionary<string, string>(GptConfigHelper.Config.Php.Config);
+
+            foreach (KeyValuePair<string, string> item in customWeb) {
+                if (configWeb.ContainsKey(item.Key)) {
+                    customWeb[item.Key] = configWeb[item.Key];
+                    configWeb.Remove(item.Key);
+                }
+            }
+
+            if (configWeb.Count > 0) {
+                customWeb = customWeb.Union(configWeb)
+                                .ToLookup(x => x.Key, x => x.Value)
+                                .ToDictionary(x => x.Key, g => g.First());
             }
 
             string customIniContent = String.Empty;
 
-            foreach (KeyValuePair<string, string> item in GptConfigHelper.Config.Php.Config) {
+            foreach (KeyValuePair<string, string> item in customWeb) {
                 customIniContent += item.Key + " = " + item.Value + "\n";
             }
 
-            File.WriteAllText(iniSettingsFolder + "/custom.ini", customIniContent);
+            File.WriteAllText(iniSettingsFolder + "/custom_web.ini", customIniContent);
+            customFilesWithPath.Add("web", iniSettingsFolder + "/custom_web.ini");
 
-            return iniSettingsFolder + "/custom.ini";
+            // Combine config and configCLI to a custom.ini for CLI
+            var configCLI = new Dictionary<string, string>(GptConfigHelper.Config.Php.ConfigCLI);
+            var customCLI = new Dictionary<string, string>(GptConfigHelper.Config.Php.Config);
+
+            foreach (KeyValuePair<string, string> item in customCLI) {
+                if (configCLI.ContainsKey(item.Key)) {
+                    customCLI[item.Key] = configCLI[item.Key];
+                    configCLI.Remove(item.Key);
+                }
+            }
+
+            if (configCLI.Count > 0) {
+                customCLI = customCLI.Union(configCLI)
+                                .ToLookup(x => x.Key, x => x.Value)
+                                .ToDictionary(x => x.Key, g => g.First());
+            }
+
+            customIniContent = String.Empty;
+
+            foreach (KeyValuePair<string, string> item in customCLI) {
+                customIniContent += item.Key + " = " + item.Value + "\n";
+            }
+
+            File.WriteAllText(iniSettingsFolder + "/custom_cli.ini", customIniContent);
+            customFilesWithPath.Add("cli", iniSettingsFolder + "/custom_cli.ini");
+
+            return customFilesWithPath;
         }
     }
 }

--- a/helper/PhpHelper.cs
+++ b/helper/PhpHelper.cs
@@ -205,28 +205,36 @@ namespace Gitpod.Tool.Helper
             AnsiConsole.MarkupLine("[green1]Done[/]");
         }
 
-        public static void AddSettingToPhpIni(string name, string value, bool isDebug)
+        public static void AddSettingToPhpIni(string name, string value, bool setForWeb = false, bool setForCLI = false, bool isDebug = false)
         {
             if (name == null || name.Length <= 3 || value == null || value.Length < 1) {
-                AnsiConsole.WriteLine("[red]Invalid name and/or value[/]");
+                AnsiConsole.MarkupLine("[red]Invalid name and/or value[/]");
 
                 return;
             }
 
-            string currentPhpVersion = PhpHelper.GetCurrentPhpVersion();
-
-            if (isDebug) {
-                AnsiConsole.WriteLine("Active PHP Version " + currentPhpVersion);
+            if (!setForWeb && !setForCLI) {
+                if (GptConfigHelper.Config.Php.Config.ContainsKey(name)) {
+                    GptConfigHelper.Config.Php.Config[name] = value;
+                } else {
+                    GptConfigHelper.Config.Php.Config.Add(name, value);
+                }
             }
 
-            if (GptConfigHelper.Config == null) {
-                GptConfigHelper.Config = new Classes.Configuration.Configuration();
+            if (setForWeb) {
+                if (GptConfigHelper.Config.Php.ConfigWeb.ContainsKey(name)) {
+                    GptConfigHelper.Config.Php.ConfigWeb[name] = value;
+                } else {
+                    GptConfigHelper.Config.Php.ConfigWeb.Add(name, value);
+                }
             }
 
-            if (GptConfigHelper.Config.Php.Config.ContainsKey(name)) {
-                GptConfigHelper.Config.Php.Config[name] = value;
-            } else {
-                GptConfigHelper.Config.Php.Config.Add(name, value);
+            if (setForCLI) {
+                if (GptConfigHelper.Config.Php.ConfigCLI.ContainsKey(name)) {
+                    GptConfigHelper.Config.Php.ConfigCLI[name] = value;
+                } else {
+                    GptConfigHelper.Config.Php.ConfigCLI.Add(name, value);
+                }
             }
 
             GptConfigHelper.WriteConfigFile();

--- a/helper/RestoreHelper.cs
+++ b/helper/RestoreHelper.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Newtonsoft.Json.Converters;
+using Spectre.Console;
+
+namespace Gitpod.Tool.Helper
+{
+    class RestoreHelper
+    {
+        public static void RestorePhpVersion(bool debug = false)
+        {
+            AnsiConsole.Write("Checking if php version has been set via config....");
+
+            if (GptConfigHelper.Config.Php.Version == String.Empty) {
+                AnsiConsole.MarkupLine("[cyan3]Not found[/]");
+
+                return;
+            }
+
+            AnsiConsole.MarkupLine("[green1]Found[/]");
+
+            PhpHelper.SetNewPhpVersion(GptConfigHelper.Config.Php.Version, debug);
+        }
+
+        public static void RestorePhpIni(bool debug = false)
+        {
+            AnsiConsole.Write("Checking if php settings has been set via config....");
+
+            if (GptConfigHelper.Config.Php.Config.Count == 0 && GptConfigHelper.Config.Php.ConfigCLI.Count == 0 && GptConfigHelper.Config.Php.ConfigWeb.Count == 0) {
+                AnsiConsole.MarkupLine("[cyan3]Not found[/]");
+
+                return;
+            }
+
+            AnsiConsole.MarkupLine("[green1]Found[/]");
+
+            PhpHelper.UpdatePhpIniFiles(debug);
+        }
+
+        public static void RestoreNodeJsVersion(bool debug = false)
+        {
+            AnsiConsole.Write("Checking if NodeJS version has been set via config....");
+
+            if (GptConfigHelper.Config.Nodejs.Version == String.Empty) {
+                AnsiConsole.MarkupLine("[cyan3]Not found[/]");
+
+                return;
+            }
+
+            AnsiConsole.MarkupLine("[green1]Found[/]");
+
+            NodeJSHelper.SetNewNodeJSVersion(GptConfigHelper.Config.Nodejs.Version, debug);
+        }
+    }
+}


### PR DESCRIPTION
Changelog:
- Include additional directories for shell scripts which can extend GPT
- PHP Settings can now be independend defined for Web and CLI
- Refined the php ini command
- PHP versions can now be selected via dropdown
- NodeJS versions can now be changed via command
- Implemented a new restore command which can restore all settings or just for php or nodejs
- Update check now supports pre-release versions
- Implemented an ask command for the Gitpod AI
- #1 
- #2 