### PR TITLE
Corrects a wrong folder dir in the update script

### DIFF
--- a/gpt.sh
+++ b/gpt.sh
@@ -18,8 +18,8 @@ fi
 dotnet "$GPTDIR/gitpod-tool.dll" "$@"
 
 # Check if the update folder exists
-if [ -d "update" ]; then
-    cd $GPTDIR
+if [ -d "/workspace/.gpt/update" ]; then
+    cd /workspace/.gpt
 
     # Move all files from the update folder to the current one and remove it afterwards
     mv update/* .


### PR DESCRIPTION
In the gpt.sh the check if the update folder exists contains an error which prevents the update command to be successull. The update will be downloaded by GPT but not beeing applied.